### PR TITLE
Add copts to mojo_library

### DIFF
--- a/mojo/mojo_library.bzl
+++ b/mojo/mojo_library.bzl
@@ -11,6 +11,7 @@ def _mojo_library_implementation(ctx):
     args.add("package")
     args.add("-strip-file-prefix=.")
     args.add("-o", mojo_package.path)
+    args.add_all(ctx.attr.copts)
 
     import_paths, transitive_mojopkgs = collect_mojoinfo(ctx.attr.deps + mojo_toolchain.implicit_deps)
     root_directory = ctx.files.srcs[0].dirname
@@ -56,6 +57,14 @@ def _mojo_library_implementation(ctx):
 mojo_library = rule(
     implementation = _mojo_library_implementation,
     attrs = {
+        "copts": attr.string_list(
+            doc = """\
+Additional compiler options to pass to the Mojo compiler.
+
+NOTE: copts from --mojocopt and mojo_toolchain.copts are not passed to 'mojo
+package' since it does not accept many flags.
+""",
+        ),
         "srcs": attr.label_list(
             allow_empty = False,
             allow_files = MOJO_EXTENSIONS,

--- a/tests/package/BUILD.bazel
+++ b/tests/package/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("//mojo:mojo_library.bzl", "mojo_library")
 
 mojo_library(
@@ -6,5 +7,15 @@ mojo_library(
         "__init__.mojo",
         "package.mojo",
     ],
+    copts = [
+        "-Ifoo",
+    ],
     visibility = ["//tests:__subpackages__"],
+)
+
+build_test(
+    name = "package_build_test",
+    targets = [
+        ":package",
+    ],
 )


### PR DESCRIPTION
These are a bit special because 'mojo package' doesn't accept target
related options like 'mojo build' does. Because of this the options
from the command line flag or toolchain aren't passed here since it
would most likely just fail as an unrecognized option.
