### PR TITLE
Allow no known shas

### DIFF
--- a/mojo/extensions.bzl
+++ b/mojo/extensions.bzl
@@ -21,7 +21,7 @@ def _mojo_toolchain_impl(rctx):
             rctx.attr.version,
             _PLATFORM_MAPPINGS[rctx.attr.platform],
         ),
-        sha256 = _KNOWN_SHAS[rctx.attr.version][rctx.attr.platform],
+        sha256 = _KNOWN_SHAS.get(rctx.attr.version, {}).get(rctx.attr.platform, ""),
         type = "zip",
         strip_prefix = "max-{}.data/platlib/max".format(rctx.attr.version),
     )


### PR DESCRIPTION
This allows arbitrary versions as long as the default URL scheme works.
I don't see any warnings from this which surprises me, but at least it
works at all.
