### PR TITLE
Add GPU detection logic

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,2 +1,5 @@
 common --incompatible_strict_action_env
 common --test_output=errors
+
+common --platforms=@mojo_host_platform
+common --host_platform=@mojo_host_platform

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -10,3 +10,8 @@ toolchain_type(
     name = "toolchain_type",
     visibility = ["//visibility:public"],
 )
+
+toolchain_type(
+    name = "gpu_toolchain_type",
+    visibility = ["//visibility:public"],
+)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,9 +11,10 @@ bazel_dep(name = "rules_python", version = "1.0.0")
 
 mojo = use_extension("//mojo:extensions.bzl", "mojo")
 mojo.toolchain()
-use_repo(mojo, "mojo_toolchains")
+mojo.gpu_toolchains()
+use_repo(mojo, "mojo_gpu_toolchains", "mojo_host_platform", "mojo_toolchains")
 
-register_toolchains("@mojo_toolchains//...")
+register_toolchains("@mojo_toolchains//...", "@mojo_gpu_toolchains//...")
 
 _DEFAULT_PYTHON_VERSION = "3.12"
 

--- a/mojo/mojo_host_platform.bzl
+++ b/mojo/mojo_host_platform.bzl
@@ -1,0 +1,146 @@
+"""Setup a host platform that takes into account current GPU hardware"""
+
+def _verbose_log(rctx, msg):
+    if rctx.getenv("MOJO_VERBOSE_GPU_DETECT"):
+        # buildifier: disable=print
+        print(msg)
+
+def _log_result(rctx, binary, result):
+    _verbose_log(
+        rctx,
+        "\n------ {}:\nexit status: {}\nstdout: {}\nstderr: {}\n------ end gpu-query info"
+            .format(binary, result.return_code, result.stdout, result.stderr),
+    )
+
+def _get_amdgpu_constraint(series, gpu_mapping):
+    for gpu_name, constraint in gpu_mapping.items():
+        if gpu_name in series:
+            if constraint:
+                return "@mojo_gpu_toolchains//:{}_gpu".format(constraint)
+            else:
+                return None
+
+    fail("Unrecognized amd-smi/rocm-smi output, please add it to your gpu_mapping in the MODULE.bazel file: {}".format(series))
+
+def _get_rocm_constraint(blob, gpu_mapping):
+    for value in blob.values():
+        series = value["Card Series"]
+        return _get_amdgpu_constraint(series, gpu_mapping)
+    fail("Unrecognized rocm-smi output, please report: {}".format(blob))
+
+def _get_amd_constraint(blob, gpu_mapping):
+    for value in blob:
+        series = value["asic"]["market_name"]
+        return _get_amdgpu_constraint(series, gpu_mapping)
+    fail("Unrecognized amd-smi output, please report: {}".format(blob))
+
+def _get_nvidia_constraint(lines, gpu_mapping):
+    line = lines[0]
+    for gpu_name, constraint in gpu_mapping.items():
+        if gpu_name in line:
+            if constraint:
+                return "@mojo_gpu_toolchains//:{}_gpu".format(constraint)
+            else:
+                return None
+
+    fail("Unrecognized nvidia-smi output, please add it to your gpu_mapping in the MODULE.bazel file: {}".format(lines))
+
+def _impl(rctx):
+    constraints = []
+
+    if rctx.os.name == "linux" and rctx.os.arch == "amd64":
+        # A system may have both rocm-smi and nvidia-smi installed, check both.
+        nvidia_smi = rctx.which("nvidia-smi")
+
+        # amd-smi supersedes rocm-smi
+        amd_smi = rctx.which("amd-smi")
+        rocm_smi = rctx.which("rocm-smi")
+
+        _verbose_log(rctx, "nvidia-smi path: {}, rocm-smi path: {}, amd-smi path: {}".format(nvidia_smi, rocm_smi, amd_smi))
+
+        # NVIDIA
+        if nvidia_smi:
+            result = rctx.execute([nvidia_smi, "--query-gpu=gpu_name", "--format=csv,noheader"])
+            _log_result(rctx, nvidia_smi, result)
+            if result.return_code == 0:
+                lines = result.stdout.splitlines()
+                if len(lines) == 0:
+                    fail("nvidia-smi succeeded but had no GPUs, please report this issue")
+
+                constraint = _get_nvidia_constraint(lines, rctx.attr.gpu_mapping)
+                if constraint:
+                    constraints.extend([
+                        "@mojo_gpu_toolchains//:nvidia_gpu",
+                        "@mojo_gpu_toolchains//:has_gpu",
+                        constraint,
+                    ])
+
+                if len(lines) > 1:
+                    constraints.append("@mojo_gpu_toolchains//:has_multi_gpu")
+                if len(lines) >= 4:
+                    constraints.append("@mojo_gpu_toolchains//:has_4_gpus")
+
+        # AMD
+        if amd_smi:
+            result = rctx.execute([amd_smi, "static", "--json"])
+            _log_result(rctx, amd_smi, result)
+
+            if result.return_code == 0:
+                constraints.extend([
+                    "@mojo_gpu_toolchains//:amd_gpu",
+                    "@mojo_gpu_toolchains//:has_gpu",
+                ])
+
+                blob = json.decode(result.stdout)
+                if len(blob) == 0:
+                    fail("amd-smi succeeded but didn't actually have any GPUs, please report this issue")
+
+                constraints.append(_get_amd_constraint(blob, rctx.attr.gpu_mapping))
+                if len(blob) > 1:
+                    constraints.append("@mojo_gpu_toolchains//:has_multi_gpu")
+                if len(blob) >= 4:
+                    constraints.append("@mojo_gpu_toolchains//:has_4_gpus")
+
+        elif rocm_smi:
+            result = rctx.execute([rocm_smi, "--json", "--showproductname"])
+            _log_result(rctx, rocm_smi, result)
+
+            if result.return_code == 0:
+                constraints.extend([
+                    "@mojo_gpu_toolchains//:amd_gpu",
+                    "@mojo_gpu_toolchains//:has_gpu",
+                ])
+
+                blob = json.decode(result.stdout)
+                if len(blob.keys()) == 0:
+                    fail("rocm-smi succeeded but didn't actually have any GPUs, please report this issue")
+
+                constraints.append(_get_rocm_constraint(blob, rctx.attr.gpu_mapping))
+                if len(blob.keys()) > 1:
+                    constraints.append("@mojo_gpu_toolchains//:has_multi_gpu")
+                if len(blob.keys()) >= 4:
+                    constraints.append("@mojo_gpu_toolchains//:has_4_gpus")
+
+    rctx.file("WORKSPACE.bazel", "workspace(name = {})".format(rctx.attr.name))
+    rctx.file("BUILD.bazel", """
+platform(
+    name = "mojo_host_platform",
+    parents = ["@platforms//host"],
+    visibility = ["//visibility:public"],
+    constraint_values = [{constraints}],
+    exec_properties = {{
+        "no-remote-exec": "1",
+    }},
+)
+""".format(constraints = ", ".join(['"{}"'.format(x) for x in constraints])))
+
+mojo_host_platform = repository_rule(
+    implementation = _impl,
+    configure = True,
+    environ = [
+        "MOJO_VERBOSE_GPU_DETECT",
+    ],
+    attrs = {
+        "gpu_mapping": attr.string_dict(),
+    },
+)

--- a/mojo/private/mojo_gpu_toolchain.bzl
+++ b/mojo/private/mojo_gpu_toolchain.bzl
@@ -1,0 +1,26 @@
+"""Bazel toolchain representing the currently targeted GPU hardware"""
+
+load("//mojo:providers.bzl", "MojoGPUToolchainInfo")
+
+def _mojo_gpu_toolchain_impl(ctx):
+    brand = ctx.attr.target_accelerator.split(":")[0]
+    return [
+        platform_common.ToolchainInfo(
+            mojo_gpu_toolchain_info = MojoGPUToolchainInfo(
+                brand = brand,
+                has_4_gpus = ctx.attr.has_4_gpus,
+                multi_gpu = ctx.attr.multi_gpu,
+                name = ctx.attr.name,
+                target_accelerator = ctx.attr.target_accelerator,
+            ),
+        ),
+    ]
+
+mojo_gpu_toolchain = rule(
+    implementation = _mojo_gpu_toolchain_impl,
+    attrs = {
+        "target_accelerator": attr.string(mandatory = True),
+        "multi_gpu": attr.bool(mandatory = True),
+        "has_4_gpus": attr.bool(mandatory = True),
+    },
+)

--- a/mojo/providers.bzl
+++ b/mojo/providers.bzl
@@ -18,3 +18,14 @@ MojoToolchainInfo = provider(
         "implicit_deps": "Implicit dependencies that every target should depend on, providing either CcInfo, or MojoInfo",
     },
 )
+
+MojoGPUToolchainInfo = provider(
+    doc = "Provider holding information about the GPU being targeted by Mojo.",
+    fields = {
+        "brand": "The brand of the GPU, e.g., 'amd', 'nvidia'",
+        "has_4_gpus": "Whether the target supports at least 4 GPUs",
+        "multi_gpu": "Whether the target supports multiple GPUs",
+        "name": "The name of the GPU, e.g., 'a100', 'mi325'",
+        "target_accelerator": "The target accelerator, e.g., '90a', 'gfx942', can be passed to the Mojo compiler",
+    },
+)

--- a/mojo/toolchain.bzl
+++ b/mojo/toolchain.bzl
@@ -8,6 +8,13 @@ def _mojo_toolchain_impl(ctx):
         tool_files.append(dep[DefaultInfo].default_runfiles.files)
         tool_files.append(dep[DefaultInfo].files_to_run)
 
+    copts = list(ctx.attr.copts)
+    gpu_toolchain = ctx.toolchains["//:gpu_toolchain_type"]
+    if gpu_toolchain:
+        copts.append("--target-accelerator=" + gpu_toolchain.mojo_gpu_toolchain_info.target_accelerator)
+    else:
+        copts.append("--target-accelerator=NONE")
+
     return [
         platform_common.ToolchainInfo(
             mojo_toolchain_info = MojoToolchainInfo(
@@ -58,4 +65,7 @@ mojo_toolchain = rule(
     doc = """\
 Defines the Mojo compiler toolchain.
 """,
+    toolchains = [
+        config_common.toolchain_type("//:gpu_toolchain_type", mandatory = False),
+    ],
 )


### PR DESCRIPTION
There are a few pieces to GPU detection for supporting Mojo. The final
goal is to have a valid value we can pass as
`--target-accelerator=nvidia:80" to `mojo build`. In order to do this
based on the target platform we have to detect the current GPU with
nvidia-smi or rocm-smi, parse the output, and setup various
config_settings to determine which toolchain should be used. If you use
`--platforms=@mojo_host_toolchain` you get the rest of this logic for
free. The currently known supported GPUs are seeded in the
`mojo.gpu_toolchains` module extension, but new ones can be added in
individual projects as well.
