### PR TITLE
Improve host platform logging

### DIFF
--- a/mojo/mojo_host_platform.bzl
+++ b/mojo/mojo_host_platform.bzl
@@ -8,8 +8,13 @@ def _verbose_log(rctx, msg):
 def _log_result(rctx, binary, result):
     _verbose_log(
         rctx,
-        "\n------ {}:\nexit status: {}\nstdout: {}\nstderr: {}\n------ end gpu-query info"
-            .format(binary, result.return_code, result.stdout, result.stderr),
+        "\n------ {binary}:\nexit status: {exit_status}\nstdout: {stdout}\nstderr: {stderr}\n------ end {binary} info"
+            .format(
+            binary = binary,
+            exit_status = result.return_code,
+            stdout = result.stdout,
+            stderr = result.stderr,
+        ),
     )
 
 def _fail(rctx, msg):


### PR DESCRIPTION
Previously the footer always said `end gpu-query info` now it includes
the CLI which is useful for AMD where we can run 2 different CLIs
