### PR TITLE
Add mojo_shared_library rule

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -32,3 +32,9 @@ pip.parse(
     requirements_lock = "tests/python/requirements.txt",
 )
 use_repo(pip, "rules_mojo_test_deps")
+
+link_hack = use_repo_rule("//mojo/private:link_hack.bzl", "link_hack")
+
+link_hack(
+    name = "build_bazel_rules_android",  # See link_hack.bzl for details
+)

--- a/mojo/mojo_shared_library.bzl
+++ b/mojo/mojo_shared_library.bzl
@@ -1,0 +1,5 @@
+"""A rule for creating shared libraries written in Mojo."""
+
+load("//mojo/private:mojo_binary_test.bzl", _mojo_shared_library = "mojo_shared_library")
+
+mojo_shared_library = _mojo_shared_library

--- a/mojo/private/link_hack.bzl
+++ b/mojo/private/link_hack.bzl
@@ -1,0 +1,15 @@
+"""This rule hacks around a private API limitation in bazel by re-using the name of a library that is allowed to access the private API.
+
+https://github.com/bazelbuild/bazel/pull/23838
+"""
+
+def _link_hack_impl(rctx):
+    rctx.file("BUILD.bazel", "")
+    rctx.file("link_hack.bzl", """\
+def link_hack(**kwargs):
+    return cc_common.link(**kwargs)
+""")
+
+link_hack = repository_rule(
+    implementation = _link_hack_impl,
+)

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("//mojo:mojo_binary.bzl", "mojo_binary")
+load("//mojo:mojo_shared_library.bzl", "mojo_shared_library")
 load("//mojo:mojo_test.bzl", "mojo_test")
 
 mojo_binary(
@@ -26,5 +27,22 @@ mojo_test(
     ],
     deps = [
         "//tests/package",
+    ],
+)
+
+mojo_shared_library(
+    name = "shared_library",
+    srcs = [
+        "shared_library.mojo",
+    ],
+)
+
+mojo_test(
+    name = "shared_library_test",
+    srcs = [
+        "shared_library_test.mojo",
+    ],
+    deps = [
+        ":shared_library",
     ],
 )

--- a/tests/python/BUILD.bazel
+++ b/tests/python/BUILD.bazel
@@ -1,4 +1,6 @@
 load("@rules_mojo_test_deps//:requirements.bzl", "requirement")
+load("@rules_python//python:defs.bzl", "py_test")
+load("//mojo:mojo_shared_library.bzl", "mojo_shared_library")
 load("//mojo:mojo_test.bzl", "mojo_test")
 
 mojo_test(
@@ -12,4 +14,16 @@ mojo_test(
     deps = [
         requirement("numpy"),
     ],
+)
+
+mojo_shared_library(
+    name = "python_shared_library",
+    srcs = ["python_shared_library.mojo"],
+    shared_lib_name = "python_shared_library.so",
+)
+
+py_test(
+    name = "python_shared_library_test",
+    srcs = ["python_shared_library_test.py"],
+    deps = [":python_shared_library"],
 )

--- a/tests/python/python_shared_library.mojo
+++ b/tests/python/python_shared_library.mojo
@@ -1,0 +1,30 @@
+from os import abort
+
+from python import Python, PythonObject
+from python.bindings import PythonModuleBuilder
+from python._cpython import PyObjectPtr
+
+
+@export
+fn PyInit_python_shared_library() -> PythonObject:
+    """Create a Python module with a function binding for `mojo_count_args`."""
+
+    try:
+        var b = PythonModuleBuilder("python_shared_library")
+        b.def_py_c_function(
+            mojo_count_args,
+            "mojo_count_args",
+            docstring="Count the provided arguments",
+        )
+        return b.finalize()
+    except e:
+        return abort[PythonObject](
+            String("failed to create Python module: ", e)
+        )
+
+
+@export
+fn mojo_count_args(py_self: PyObjectPtr, args: PyObjectPtr) -> PyObjectPtr:
+    var cpython = Python().cpython()
+
+    return PythonObject(cpython.PyObject_Length(args)).py_object

--- a/tests/python/python_shared_library_test.py
+++ b/tests/python/python_shared_library_test.py
@@ -1,0 +1,6 @@
+import python_shared_library
+
+if __name__ == "__main__":
+    result = python_shared_library.mojo_count_args(1, 2)
+    assert result == 2
+    print("Result from Mojo 🔥:", result)

--- a/tests/shared_library.mojo
+++ b/tests/shared_library.mojo
@@ -1,0 +1,3 @@
+@export
+fn foo() -> Int:
+    return 42

--- a/tests/shared_library_test.mojo
+++ b/tests/shared_library_test.mojo
@@ -1,0 +1,8 @@
+from sys.ffi import c_int, external_call
+from testing import assert_equal
+
+def main():
+    print("Calling external function...")
+    result = external_call["foo", c_int]()
+    print("Result from external function:", result)
+    assert_equal(result, 42)


### PR DESCRIPTION
This allows you to produce a shared library from mojo code. This can be
used to create native python extensions as seen in the tests. This
requires 1 major hack documented in link_hack.bzl to get shared
libraries with the right filename for python.
