### PR TITLE
Add orc_rt to mojo toolchain

### DIFF
--- a/mojo/private/toolchain.BUILD
+++ b/mojo/private/toolchain.BUILD
@@ -46,5 +46,6 @@ mojo_toolchain(
     ] + ([":all_mojopkgs"] if "{INCLUDE_MOJOPKGS}" else []),
     lld = "bin/lld",
     mojo = "bin/mojo",
+    orc_rt = "lib/liborc_rt.a",
     visibility = ["//visibility:public"],
 )

--- a/mojo/providers.bzl
+++ b/mojo/providers.bzl
@@ -16,6 +16,7 @@ MojoToolchainInfo = provider(
         "lld": "The lld compiler executable to link with",
         "mojo": "The mojo compiler executable to build with",
         "implicit_deps": "Implicit dependencies that every target should depend on, providing either CcInfo, or MojoInfo",
+        "orc_rt": "The ORC runtime library used for 'mojo run'.",
     },
 )
 

--- a/mojo/toolchain.bzl
+++ b/mojo/toolchain.bzl
@@ -23,6 +23,7 @@ def _mojo_toolchain_impl(ctx):
                 lld = ctx.executable.lld,
                 mojo = ctx.executable.mojo,
                 implicit_deps = ctx.attr.implicit_deps,
+                orc_rt = ctx.file.orc_rt,
             ),
         ),
     ]
@@ -60,6 +61,12 @@ mojo_toolchain = rule(
             mandatory = True,
             cfg = "target",
             doc = "Implicit dependencies that every target should depend on, providing either CcInfo, or MojoInfo.",
+        ),
+        "orc_rt": attr.label(
+            allow_single_file = True,
+            mandatory = True,
+            cfg = "target",
+            doc = "The ORC runtime library used for 'mojo run'.",
         ),
     },
     doc = """\


### PR DESCRIPTION
This library has to be available in the environment when using 'mojo
run'. This isn't in any of the default fields used today, but can be
useful for custom rules.
