### PR TITLE
Add fail for invalid python version transition

### DIFF
--- a/mojo/private/transitions.bzl
+++ b/mojo/private/transitions.bzl
@@ -5,7 +5,10 @@ _PYTHON_VERSION = "@rules_python//python/config_settings:python_version"
 def _python_version_transition_impl(settings, attr):
     output = {_PYTHON_VERSION: settings[_PYTHON_VERSION]}
     if attr.python_version:
+        if "_" in attr.python_version:
+            fail("error: invalid python version: ", attr.python_version)
         output["@rules_python//python/config_settings:python_version"] = str(attr.python_version)
+
     return output
 
 python_version_transition = transition(


### PR DESCRIPTION
Since it's common to use 3_12 etc versions various places in bazel, this
makes sure if you ever accidentally use that in the transition that it
fails, since otherwise it will fail with an opaque toolchain error
