### PR TITLE
Fix `mojo_library` taking dependencies that require file path expansion

### DIFF
--- a/mojo/mojo_library.bzl
+++ b/mojo/mojo_library.bzl
@@ -43,13 +43,10 @@ def _mojo_library_implementation(ctx):
         },
         use_default_shell_env = True,
         toolchain = "//:toolchain_type",
-        execution_requirements = {
-            "supports-path-mapping": "1",
-        },
     )
 
     transitive_runfiles = []
-    for target in ctx.attr.data:
+    for target in ctx.attr.data + ctx.attr.deps:
         transitive_runfiles.append(target[DefaultInfo].default_runfiles)
 
     return [


### PR DESCRIPTION
Previously the `mojo package` command was unable to find bitcode
libraries that were specified in `additional_compiler_inputs`, this
exposes the file to the correct path.
