### PR TITLE
Set PATH to something invalid

### DIFF
--- a/mojo/mojo_library.bzl
+++ b/mojo/mojo_library.bzl
@@ -39,6 +39,7 @@ def _mojo_library_implementation(ctx):
         progress_message = "%{label} building mojo package",
         env = {
             "MODULAR_CRASH_REPORTING_ENABLED": "false",
+            "PATH": "/dev/null",  # Avoid using the host's PATH
             "TEST_TMPDIR": ".",  # Make sure any cache files are written to somewhere bazel will cleanup
         },
         use_default_shell_env = True,

--- a/mojo/private/mojo_binary_test.bzl
+++ b/mojo/private/mojo_binary_test.bzl
@@ -126,6 +126,7 @@ def _mojo_binary_test_implementation(ctx, *, shared_library = False):
             "MODULAR_MOJO_MAX_COMPILERRT_PATH": "/dev/null",  # Make sure this fails if accessed
             "MODULAR_MOJO_MAX_LINKER_DRIVER": "/dev/null",  # Make sure this fails if accessed
             "MODULAR_MOJO_MAX_LLD_PATH": mojo_toolchain.lld.path,
+            "PATH": "/dev/null",  # Avoid using the host's PATH
             "TEST_TMPDIR": ".",
         },
         use_default_shell_env = True,


### PR DESCRIPTION
This makes sure that if mojo attempts to find something on the PATH it
fails. Everything it needs should come through the environment
variables. This is a safety net for it trying to find the system linker
or linker driver.
