### PR TITLE
Use mojo_compiler wheel to pull mojo

### DIFF
--- a/mojo/extensions.bzl
+++ b/mojo/extensions.bzl
@@ -4,7 +4,7 @@ load("//mojo:mojo_host_platform.bzl", "mojo_host_platform")
 load("//mojo/private:mojo_gpu_toolchains_repository.bzl", "mojo_gpu_toolchains_repository")
 
 _PLATFORMS = ["linux_aarch64", "linux_x86_64", "macos_arm64"]
-_DEFAULT_VERSION = "25.5.0.dev2025062305"
+_DEFAULT_VERSION = "25.6.0.dev2025082505"
 _KNOWN_SHAS = {
     "25.4.0.dev2025050902": {
         "linux_aarch64": "d52c67f245575397d8176010d27bd12e76cde297ed8ee7f07dcc73fe48955508",
@@ -15,6 +15,11 @@ _KNOWN_SHAS = {
         "linux_aarch64": "7b516b9ef485cc25f981d438bba974108dc115509d17f58431866bde8f962043",
         "linux_x86_64": "51302b87d8d83891762877be0bf73fffbf196a47246be339e818c4b3480e1ac4",
         "macos_arm64": "694e3be8f2180a67602e781fcbde5c0241d1b5951300962a04d5e695ead7db28",
+    },
+    "25.6.0.dev2025082505": {
+        "linux_aarch64": "7ded0c7fb541ced6feacb29fa202242b51e628362d9c4ae32edd02479cbe21fe",
+        "linux_x86_64": "a3cf93ce991a0d4b162105e0fc4fbeb6edabc55b7c5457796161d055cdb1ccfd",
+        "macos_arm64": "439cd3d0ed19e27d623dc2a292c5356f4ccc1c89f0044f073caf3a23f2759b26",
     },
 }
 _PLATFORM_MAPPINGS = {

--- a/mojo/extensions.bzl
+++ b/mojo/extensions.bzl
@@ -31,14 +31,14 @@ _NULL_SHAS = {
 def _mojo_toolchain_impl(rctx):
     base_url = rctx.attr.base_url or "https://dl.modular.com/public/nightly/python"
     rctx.download_and_extract(
-        url = "{}/max-{}-py3-none-{}.whl".format(
+        url = "{}/mojo_compiler-{}-py3-none-{}.whl".format(
             base_url,
             rctx.attr.version,
             _PLATFORM_MAPPINGS[rctx.attr.platform],
         ),
         sha256 = _KNOWN_SHAS.get(rctx.attr.version, _NULL_SHAS)[rctx.attr.platform],
         type = "zip",
-        strip_prefix = "max-{}.data/platlib/max".format(rctx.attr.version),
+        strip_prefix = "mojo_compiler-{}.data/platlib/modular".format(rctx.attr.version),
     )
 
     rctx.template(

--- a/tests/package/package.mojo
+++ b/tests/package/package.mojo
@@ -1,4 +1,4 @@
-import compiler  # All vendored depenencies are available
+import layout  # All vendored dependencies are available
 
 fn foo() -> Int:
     return 42

--- a/tests/python/python_shared_library.mojo
+++ b/tests/python/python_shared_library.mojo
@@ -25,6 +25,7 @@ fn PyInit_python_shared_library() -> PythonObject:
 
 @export
 fn mojo_count_args(py_self: PyObjectPtr, args: PyObjectPtr) -> PyObjectPtr:
-    var cpython = Python().cpython()
+    ref cpython = Python().cpython()
 
-    return PythonObject(cpython.PyObject_Length(args)).py_object
+    var count = cpython.PyObject_Length(args)
+    return cpython.PyLong_FromSsize_t(count)

--- a/tools/getshas.sh
+++ b/tools/getshas.sh
@@ -14,9 +14,9 @@ fi
 readonly version=$1
 directory=$(mktemp -d)
 
-curl --location --fail --output "$directory/linux_x86_64" "https://dl.modular.com/public/nightly/python/max-$version-py3-none-manylinux_2_34_x86_64.whl"
-curl --location --fail --output "$directory/linux_aarch64" "https://dl.modular.com/public/nightly/python/max-$version-py3-none-manylinux_2_34_aarch64.whl"
-curl --location --fail --output "$directory/macos" "https://dl.modular.com/public/nightly/python/max-$version-py3-none-macosx_13_0_arm64.whl"
+curl --location --fail --output "$directory/linux_x86_64" "https://dl.modular.com/public/nightly/python/mojo_compiler-$version-py3-none-manylinux_2_34_x86_64.whl"
+curl --location --fail --output "$directory/linux_aarch64" "https://dl.modular.com/public/nightly/python/mojo_compiler-$version-py3-none-manylinux_2_34_aarch64.whl"
+curl --location --fail --output "$directory/macos" "https://dl.modular.com/public/nightly/python/mojo_compiler-$version-py3-none-macosx_13_0_arm64.whl"
 
 cat <<EOF
 "$version": {


### PR DESCRIPTION
Pulling in https://github.com/modular/modular/blob/main/bazel/public-patches/rules_mojo_use_mojo_compiler_wheel.patch, that patch needed to be atomic to that commit.

Failing on the latest green sha, annoyingly can't repro locally?