### PR TITLE
Fix some amd-smi parsing cases

### DIFF
--- a/mojo/mojo_host_platform.bzl
+++ b/mojo/mojo_host_platform.bzl
@@ -42,8 +42,10 @@ def _get_rocm_constraint(rctx, blob, gpu_mapping):
     fail("Unrecognized rocm-smi output, please report: {}".format(blob))
 
 def _get_amd_constraint(rctx, blob, gpu_mapping):
+    if "gpu_data" in blob:
+        blob = blob["gpu_data"]
     for value in blob:
-        series = value["asic"]["market_name"]
+        series = value["board"]["product_name"]
         return _get_amdgpu_constraint(rctx, series, gpu_mapping)
     fail("Unrecognized amd-smi output, please report: {}".format(blob))
 


### PR DESCRIPTION
Newer amd-smi versions nest the actual data under a `gpu_data` key. They
also put generic strings in `market_name` but it looks like
`board.product_name` always has what we actually want.
