### PR TITLE
Add target_compatible_with toolchain constraints

### DIFF
--- a/mojo/extensions.bzl
+++ b/mojo/extensions.bzl
@@ -86,6 +86,10 @@ toolchain(
         "@platforms//cpu:{cpu}",
         "@platforms//os:{os}",
     ],
+    target_compatible_with = [  # Wheels only contain support libraries for 1 platform and cross OS compilation is not supported.
+        "@platforms//cpu:{cpu}",
+        "@platforms//os:{os}",
+    ],
     toolchain = "@mojo_toolchain_{platform}//:mojo_toolchain",
     toolchain_type = "@rules_mojo//:toolchain_type",
 )


### PR DESCRIPTION
Mojo can cross compile CPU and GPU targets, but the single wheels we
pull only have the configuration for the same OS / arch target (we could
support pulling 2 wheels for a single toolchain, but aren't right now).
Mojo cannot cross compile OS differences (linux -> macOS or macOS ->
linux) because of OS specific GPU libraries in the compiler. This
correctly reflects that in remote execution scenarios.
