### PR TITLE
Try harder to handle amd-smi invalid json

### DIFF
--- a/mojo/mojo_host_platform.bzl
+++ b/mojo/mojo_host_platform.bzl
@@ -162,7 +162,10 @@ def _impl(rctx):
                     if line.startswith("WARNING:"):
                         continue
                     json_lines.append(line)
-                blob = json.decode("\n".join(json_lines))
+                failure_sentinel = {"DECODE": "FAILED"}
+                blob = json.decode("\n".join(json_lines), default = failure_sentinel)
+                if blob == failure_sentinel:
+                    fail("amd-smi output was not valid json, please report this issue: {}".format(result.stdout))
                 if len(blob) == 0:
                     fail("amd-smi succeeded but didn't actually have any GPUs, please report this issue")
 


### PR DESCRIPTION
We see more cases of this issue, I think the case is more fatal than
before so now we just error but at least print the invalid json when we
hit it. Warnings are still ignored

https://github.com/ROCm/amdsmi/pull/114
