### PR TITLE
Add aarch64 as a viable Linux system for detection of NVIDIA or AMD GPUs

### DIFF
--- a/mojo/mojo_host_platform.bzl
+++ b/mojo/mojo_host_platform.bzl
@@ -124,7 +124,7 @@ def _get_apple_constraint(rctx, gpu_mapping):
 def _impl(rctx):
     constraints = []
 
-    if rctx.os.name == "linux" and rctx.os.arch == "amd64":
+    if rctx.os.name == "linux" and (rctx.os.arch == "amd64" or rctx.os.arch == "aarch64"):
         # A system may have both rocm-smi and nvidia-smi installed, check both.
         nvidia_smi = rctx.which("nvidia-smi")
 


### PR DESCRIPTION
Systems like the DGX Spark, Jetson Thor, or GB200 have aarch64 hosts with NVIDIA GPUs. Currently, checks for GPUs don't work on those systems, limiting the use of Bazel for them. This adds aarch64 as a viable option on Linux for searching for GPUs on these systems. With a local version of this fix, I was able to get Bazel to find the GPU on the DGX Spark and support the correct tests and targets for that platform.

AMD equivalents are less common, but people have gotten ROCm GPUs running on aarch64 systems, so I don't think it hurts to apply this across checks for both manufacturers.