### PR TITLE
Rename 'mojopkg' to 'mojoc'

### DIFF
--- a/mojo/extensions.bzl
+++ b/mojo/extensions.bzl
@@ -68,7 +68,7 @@ _mojo_toolchain_repository = repository_rule(
             default = "",
         ),
         "use_prebuilt_packages": attr.bool(
-            doc = "Whether to automatically add prebuilt mojopkgs to every mojo target.",
+            doc = "Whether to automatically add prebuilt mojo packages to every mojo target.",
             mandatory = True,
         ),
         "_template": attr.label(
@@ -177,7 +177,7 @@ _toolchain_tag = tag_class(
             default = "",
         ),
         "use_prebuilt_packages": attr.bool(
-            doc = "Whether to automatically add prebuilt mojopkgs to every mojo target.",
+            doc = "Whether to automatically add prebuilt mojo packages to every mojo target.",
             default = True,
         ),
     },

--- a/mojo/mojo_import.bzl
+++ b/mojo/mojo_import.bzl
@@ -1,29 +1,29 @@
-"""Import a prebuilt mojopkg for use in other Mojo targets."""
+"""Import a precompiled mojo file for use in other Mojo targets."""
 
 load("//mojo:providers.bzl", "MojoInfo")
 load("//mojo/private:utils.bzl", "collect_mojoinfo")
 
 def _mojo_import_impl(ctx):
-    mojo_packages = ctx.files.mojopkgs
-    import_paths, transitive_mojopkgs = collect_mojoinfo(ctx.attr.deps)
+    mojo_deps = ctx.files.mojodeps
+    import_paths, transitive_mojodeps = collect_mojoinfo(ctx.attr.deps)
     return [
-        DefaultInfo(files = depset(mojo_packages, transitive = [transitive_mojopkgs])),
+        DefaultInfo(files = depset(mojo_deps, transitive = [transitive_mojodeps])),
         MojoInfo(
-            import_paths = depset([pkg.dirname for pkg in mojo_packages], transitive = [import_paths]),
-            mojopkgs = depset([pkg for pkg in mojo_packages], transitive = [transitive_mojopkgs]),
+            import_paths = depset([pkg.dirname for pkg in mojo_deps], transitive = [import_paths]),
+            mojodeps = depset([pkg for pkg in mojo_deps], transitive = [transitive_mojodeps]),
         ),
     ]
 
 mojo_import = rule(
     implementation = _mojo_import_impl,
     attrs = {
-        "mojopkgs": attr.label_list(
-            allow_files = [".mojopkg"],
-            doc = "The mojopkg files to import.",
+        "mojodeps": attr.label_list(
+            allow_files = [".mojopkg", ".mojoc"],
+            doc = "The precompiled mojo files to import.",
         ),
         "deps": attr.label_list(
             providers = [MojoInfo],
-            doc = "Additional Mojo dependencies required by the imported mojopkg.",
+            doc = "Additional Mojo dependencies required by the imported mojo file.",
         ),
     },
 )

--- a/mojo/mojo_library.bzl
+++ b/mojo/mojo_library.bzl
@@ -1,4 +1,5 @@
-"""Compile Mojo files into a mojopkg that can be consumed by other Mojo targets."""
+"""Compile Mojo files into a precompiled object (mojoc) that can be consumed by
+other Mojo targets."""
 
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load("//mojo:providers.bzl", "MojoInfo")
@@ -25,7 +26,7 @@ def _mojo_library_implementation(ctx):
         for copt in ctx.attr.copts
     ])
 
-    import_paths, transitive_mojopkgs = collect_mojoinfo(ctx.attr.deps + mojo_toolchain.implicit_deps)
+    import_paths, transitive_mojodeps = collect_mojoinfo(ctx.attr.deps + mojo_toolchain.implicit_deps)
     root_directory = ctx.files.srcs[0].dirname
 
     file_args = ctx.actions.args()
@@ -41,11 +42,11 @@ def _mojo_library_implementation(ctx):
         output_group_kwargs["mojo_fixits"] = depset([fixits_file])
         args.add("--experimental-export-fixit", fixits_file)
 
-    file_args.add_all(transitive_mojopkgs, map_each = _format_include)
+    file_args.add_all(transitive_mojodeps, map_each = _format_include)
     file_args.add(root_directory)
     ctx.actions.run(
         executable = mojo_toolchain.mojo,
-        inputs = depset(ctx.files.srcs + ctx.files.additional_compiler_inputs, transitive = [transitive_mojopkgs]),
+        inputs = depset(ctx.files.srcs + ctx.files.additional_compiler_inputs, transitive = [transitive_mojodeps]),
         tools = mojo_toolchain.all_tools,
         outputs = package_outputs,
         arguments = [args, file_args],
@@ -74,7 +75,7 @@ def _mojo_library_implementation(ctx):
         ),
         MojoInfo(
             import_paths = depset([mojo_package.dirname], transitive = [import_paths]),
-            mojopkgs = depset([mojo_package], transitive = [transitive_mojopkgs]),
+            mojodeps = depset([mojo_package], transitive = [transitive_mojodeps]),
         ),
         OutputGroupInfo(**output_group_kwargs),
     ]

--- a/mojo/private/mojo_binary_test.bzl
+++ b/mojo/private/mojo_binary_test.bzl
@@ -113,7 +113,7 @@ def _mojo_binary_test_implementation(ctx, *, shared_library = False):
             args.add("-I", file.dirname)
 
     all_deps = ctx.attr.deps + mojo_toolchain.implicit_deps + ([ctx.attr._link_extra_lib] if ctx.attr._link_extra_lib else [])
-    import_paths, transitive_mojopkgs = collect_mojoinfo(all_deps)
+    import_paths, transitive_mojodeps = collect_mojoinfo(all_deps)
     args.add_all(import_paths, before_each = "-I")
 
     # NOTE: Argument order:
@@ -145,7 +145,7 @@ def _mojo_binary_test_implementation(ctx, *, shared_library = False):
     ctx.actions.run(
         executable = mojo_toolchain.mojo,
         tools = mojo_toolchain.all_tools,
-        inputs = depset(ctx.files.srcs + ctx.files.additional_compiler_inputs, transitive = [transitive_mojopkgs]),
+        inputs = depset(ctx.files.srcs + ctx.files.additional_compiler_inputs, transitive = [transitive_mojodeps]),
         outputs = compile_outputs,
         arguments = [args],
         mnemonic = "MojoCompile",

--- a/mojo/private/toolchain.BUILD
+++ b/mojo/private/toolchain.BUILD
@@ -33,10 +33,13 @@ _INTERNAL_LIBRARIES = [
 ]
 
 mojo_import(
-    name = "all_mojopkgs",
-    mojopkgs = glob(
+    name = "all_mojodeps",
+    mojodeps = glob(
         ["lib/mojo/**/*.mojopkg"],
         allow_empty = False,
+    ) + glob(
+        ["lib/mojo/**/*.mojoc"],
+        allow_empty = True,
     ),
 )
 
@@ -46,7 +49,7 @@ mojo_toolchain(
     implicit_deps = [
         name
         for name, _ in _INTERNAL_LIBRARIES
-    ] + ([":all_mojopkgs"] if "{INCLUDE_MOJOPKGS}" else []),
+    ] + ([":all_mojodeps"] if "{INCLUDE_MOJOPKGS}" else []),
     lld = "bin/lld",
     mojo = "bin/mojo",
     visibility = ["//visibility:public"],

--- a/mojo/private/utils.bzl
+++ b/mojo/private/utils.bzl
@@ -15,14 +15,14 @@ def collect_mojoinfo(deps):
         A single MojoInfo object with the combined data.
     """
     import_paths = []
-    mojopkgs = []
+    mojodeps = []
     for dep in deps:
         if MojoInfo in dep:
             info = dep[MojoInfo]
-            mojopkgs.append(info.mojopkgs)
+            mojodeps.append(info.mojodeps)
             import_paths.append(info.import_paths)
 
-    return depset(transitive = import_paths), depset(transitive = mojopkgs)
+    return depset(transitive = import_paths), depset(transitive = mojodeps)
 
 def is_exec_config(ctx):
     """Determines whether the current configuration is an exec configuration.

--- a/mojo/providers.bzl
+++ b/mojo/providers.bzl
@@ -4,7 +4,7 @@ MojoInfo = provider(
     doc = "Information about how to build a Mojo target.",
     fields = {
         "import_paths": "Directories that should be passed with -I to mojo",
-        "mojopkgs": "The mojopkg files required by the target",
+        "mojodeps": "The precompiled mojo files required by the target",
     },
 )
 


### PR DESCRIPTION
This forms part of the renaming of `.mojopkg` to `.mojoc`.

In certain cases some form of "dep" or "mojodep" is used to convey dependencies as a concept rather than being overly specific about the file type.