### PR TITLE
Rename 'mojo package' to 'mojo precompile'

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -8,7 +8,7 @@ repeatable_string_flag(
 )
 
 repeatable_string_flag(
-    name = "mojo_package_copt",
+    name = "mojo_precompile_copt",
     build_setting_default = [],
     visibility = ["//visibility:public"],
 )

--- a/mojo/extensions.bzl
+++ b/mojo/extensions.bzl
@@ -6,11 +6,11 @@ load("//mojo/private:mojo_gpu_toolchains_repository.bzl", "mojo_gpu_toolchains_r
 _PLATFORMS = ["linux_aarch64", "linux_x86_64", "macos_arm64"]
 _DEFAULT_VERSION = "0.26.3.0.dev2026031105"
 _KNOWN_SHAS = {
-    "0.26.3.0.dev2026031105": {
-        "linux_aarch64": "a62136e7d0bd0a44bc0d0b62e6179180d721c99c7308fd4c666885c37f43740e",
-        "linux_x86_64": "acf1777039b79c9f75e814ca0124ab913c02a68a4f4bb919e6fed183fa2f2602",
-        "macos_arm64": "50b994a44fa52f2487e81e288dbb2e417da7132fffe0e908a2e3a1ec9418e42e",
-        "mojo_compiler_mojo_libs": "32fb42e57af02309f35b668c0e4eb78fc87d0459165dca0a10223ab6d37a5cb3",
+    "1.0.0b2.dev2026051806": {
+        "linux_aarch64": "224c4c1590debdff509bde74ead2da7b3eef2bc052380627e824072fe18bef05",
+        "linux_x86_64": "7775e0386cb564cfd09f34c74209b80fc5a5d43b5ac20e36e638032e0f0cd63a",
+        "macos_arm64": "5effdfe6fa9962802bba236baa15541584d7c27e3224d304d39d00912113fe58",
+        "mojo_compiler_mojo_libs": "63e7bcbca2f311d6aba0c90cdd3c1152d153ee3f0f65ccc5c4f06f61b84c06e4",
     },
 }
 _PLATFORM_MAPPINGS = {

--- a/mojo/extensions.bzl
+++ b/mojo/extensions.bzl
@@ -4,7 +4,7 @@ load("//mojo:mojo_host_platform.bzl", "mojo_host_platform")
 load("//mojo/private:mojo_gpu_toolchains_repository.bzl", "mojo_gpu_toolchains_repository")
 
 _PLATFORMS = ["linux_aarch64", "linux_x86_64", "macos_arm64"]
-_DEFAULT_VERSION = "0.26.3.0.dev2026031105"
+_DEFAULT_VERSION = "1.0.0b2.dev2026051806"
 _KNOWN_SHAS = {
     "1.0.0b2.dev2026051806": {
         "linux_aarch64": "224c4c1590debdff509bde74ead2da7b3eef2bc052380627e824072fe18bef05",

--- a/mojo/mojo_library.bzl
+++ b/mojo/mojo_library.bzl
@@ -12,15 +12,15 @@ def _mojo_library_implementation(ctx):
     mojo_toolchain = ctx.toolchains["//:toolchain_type"].mojo_toolchain_info
     build_env = getattr(ctx.toolchains["//:toolchain_type"], "build_env", {})
 
-    mojo_package = ctx.actions.declare_file(ctx.label.name + ".mojopkg")
+    mojo_precmp_file = ctx.actions.declare_file(ctx.label.name + ".mojoc")
     args = ctx.actions.args()
-    args.add("package")
+    args.add("precompile")
     args.add("-strip-file-prefix=.")
-    args.add("-o", mojo_package)
+    args.add("-o", mojo_precmp_file)
 
-    args.add_all(mojo_toolchain.package_copts)
+    args.add_all(mojo_toolchain.precompile_copts)
     if not is_exec_config(ctx):
-        args.add_all(ctx.attr._mojo_package_copts[BuildSettingInfo].value)
+        args.add_all(ctx.attr._mojo_precompile_copts[BuildSettingInfo].value)
     args.add_all([
         ctx.expand_location(copt, targets = ctx.attr.additional_compiler_inputs)
         for copt in ctx.attr.copts
@@ -35,10 +35,10 @@ def _mojo_library_implementation(ctx):
             args.add_all([file], map_each = _format_include)
 
     output_group_kwargs = {}
-    package_outputs = [mojo_package]
+    precompile_outputs = [mojo_precmp_file]
     if ctx.attr._export_fixits[BuildSettingInfo].value:
         fixits_file = ctx.actions.declare_file(ctx.label.name + ".mojo_fixits.yaml")
-        package_outputs.append(fixits_file)
+        precompile_outputs.append(fixits_file)
         output_group_kwargs["mojo_fixits"] = depset([fixits_file])
         args.add("--experimental-export-fixit", fixits_file)
 
@@ -48,10 +48,10 @@ def _mojo_library_implementation(ctx):
         executable = mojo_toolchain.mojo,
         inputs = depset(ctx.files.srcs + ctx.files.additional_compiler_inputs, transitive = [transitive_mojodeps]),
         tools = mojo_toolchain.all_tools,
-        outputs = package_outputs,
+        outputs = precompile_outputs,
         arguments = [args, file_args],
-        mnemonic = "MojoPackage",
-        progress_message = "%{label} building mojo package",
+        mnemonic = "MojoPrecompile",
+        progress_message = "%{label} precompiling mojo file",
         env = {
             "MODULAR_CRASH_REPORTING_ENABLED": "false",
             "PATH": "/dev/null",  # Avoid using the host's PATH
@@ -70,12 +70,12 @@ def _mojo_library_implementation(ctx):
 
     return [
         DefaultInfo(
-            files = depset([mojo_package]),
+            files = depset([mojo_precmp_file]),
             runfiles = ctx.runfiles(ctx.files.data).merge_all(transitive_runfiles),
         ),
         MojoInfo(
-            import_paths = depset([mojo_package.dirname], transitive = [import_paths]),
-            mojodeps = depset([mojo_package], transitive = [transitive_mojodeps]),
+            import_paths = depset([mojo_precmp_file.dirname], transitive = [import_paths]),
+            mojodeps = depset([mojo_precmp_file], transitive = [transitive_mojodeps]),
         ),
         OutputGroupInfo(**output_group_kwargs),
     ]
@@ -95,13 +95,13 @@ then be used in copts with the $(location) function.
 Additional compiler options to pass to the Mojo compiler.
 
 Order of options:
-1. copts from mojo_toolchain.package_copts
-2. copts from //:mojo_package_copt (if not building in exec config)
+1. copts from mojo_toolchain.precompile_copts
+2. copts from //:mojo_precompile_copt (if not building in exec config)
 3. copts from this attribute, with $(location) expanded for files in
    additional_compiler_inputs.
 
 NOTE: copts from --mojocopt and mojo_toolchain.copts are not passed to 'mojo
-package' since it does not accept many flags.
+precompile' since it does not accept many flags.
 """,
         ),
         "srcs": attr.label_list(
@@ -112,8 +112,8 @@ package' since it does not accept many flags.
             providers = [MojoInfo],
         ),
         "data": attr.label_list(),
-        "_mojo_package_copts": attr.label(
-            default = Label("//:mojo_package_copt"),
+        "_mojo_precompile_copts": attr.label(
+            default = Label("//:mojo_precompile_copt"),
         ),
         "_export_fixits": attr.label(
             default = Label("@rules_mojo//:experimental_export_fixits"),

--- a/mojo/providers.bzl
+++ b/mojo/providers.bzl
@@ -13,7 +13,7 @@ MojoToolchainInfo = provider(
     fields = {
         "all_tools": "All the files that must be available in actions in order for the toolchain to work.",
         "copts": "Additional compiler options to pass to the Mojo compiler.",
-        "package_copts": "Additional compiler options to pass to the Mojo compiler when running 'mojo package'.",
+        "precompile_copts": "Additional compiler options to pass to the Mojo compiler when running 'mojo precompile'.",
         "lld": "The lld compiler executable to link with",
         "mojo": "The mojo compiler executable to build with",
         "implicit_deps": "Implicit dependencies that every target should depend on, providing either CcInfo, or MojoInfo",
@@ -24,7 +24,7 @@ MojoCoptsToolchainInfo = provider(
     doc = "Provider holding additional compiler options for the Mojo compiler.",
     fields = {
         "copts": "Additional compiler options to pass to the Mojo compiler.",
-        "package_copts": "Additional compiler options to pass to the Mojo compiler when running 'mojo package'.",
+        "precompile_copts": "Additional compiler options to pass to the Mojo compiler when running 'mojo precompile'.",
     },
 )
 

--- a/mojo/toolchain.bzl
+++ b/mojo/toolchain.bzl
@@ -10,7 +10,7 @@ def _mojo_toolchain_impl(ctx):
         tool_files.append(dep[DefaultInfo].files)
 
     copts = list(ctx.attr.copts)
-    package_copts = list(ctx.attr.package_copts)
+    precompile_copts = list(ctx.attr.precompile_copts)
     gpu_toolchain = ctx.toolchains["//:gpu_toolchain_type"]
     if gpu_toolchain:
         copts.append("--target-accelerator=" + gpu_toolchain.mojo_gpu_toolchain_info.target_accelerator)
@@ -24,14 +24,14 @@ def _mojo_toolchain_impl(ctx):
     copts_toolchain = ctx.toolchains["//:copts_toolchain_type"]
     if copts_toolchain:
         copts.extend(copts_toolchain.copts_toolchain_info.copts)
-        package_copts = copts_toolchain.copts_toolchain_info.package_copts
+        precompile_copts = copts_toolchain.copts_toolchain_info.precompile_copts
 
     return [
         platform_common.ToolchainInfo(
             mojo_toolchain_info = MojoToolchainInfo(
                 all_tools = tool_files,
                 copts = copts,
-                package_copts = package_copts,
+                precompile_copts = precompile_copts,
                 lld = ctx.executable.lld,
                 mojo = ctx.executable.mojo,
                 implicit_deps = ctx.attr.implicit_deps,
@@ -46,9 +46,9 @@ mojo_toolchain = rule(
             mandatory = False,
             doc = "Additional compiler options to pass to the Mojo compiler.",
         ),
-        "package_copts": attr.string_list(
+        "precompile_copts": attr.string_list(
             mandatory = False,
-            doc = "Additional compiler options to pass to the Mojo compiler when running 'mojo package'.",
+            doc = "Additional compiler options to pass to the Mojo compiler when running 'mojo precompile'.",
         ),
         "extra_tools": attr.label_list(
             providers = [DefaultInfo],
@@ -96,7 +96,7 @@ def _mojo_copts_toolchain_impl(ctx):
         platform_common.ToolchainInfo(
             copts_toolchain_info = MojoCoptsToolchainInfo(
                 copts = ctx.attr.copts,
-                package_copts = ctx.attr.package_copts,
+                precompile_copts = ctx.attr.precompile_copts,
             ),
         ),
     ]
@@ -108,9 +108,9 @@ mojo_copts_toolchain = rule(
             mandatory = True,
             doc = "Additional compiler options to pass to the Mojo compiler.",
         ),
-        "package_copts": attr.string_list(
+        "precompile_copts": attr.string_list(
             mandatory = True,
-            doc = "Additional compiler options to pass to the Mojo compiler when running 'mojo package'.",
+            doc = "Additional compiler options to pass to the Mojo compiler when running 'mojo precompile'.",
         ),
     },
     doc = """\

--- a/tests/cc/cc_test.mojo
+++ b/tests/cc/cc_test.mojo
@@ -1,4 +1,4 @@
 from std.ffi import external_call
 
-fn main() raises:
+def main() raises:
     external_call["foo", NoneType]()

--- a/tests/fixits/fixits.mojo
+++ b/tests/fixits/fixits.mojo
@@ -1,5 +1,5 @@
-fn old_origin_of[T: AnyType](b: T):
+def old_origin_of[T: AnyType](b: T):
     _ = __origin_of(b)
 
-fn main():
+def main():
     pass

--- a/tests/fixits/package/package.mojo
+++ b/tests/fixits/package/package.mojo
@@ -1,2 +1,2 @@
-fn old_origin_of[T: AnyType](b: T):
+def old_origin_of[T: AnyType](b: T):
     _ = __origin_of(b)

--- a/tests/hello_world.mojo
+++ b/tests/hello_world.mojo
@@ -1,4 +1,4 @@
 from package.package import foo
 
-fn main():
+def main():
     print("Hello, World!", foo())

--- a/tests/hello_world_test.mojo
+++ b/tests/hello_world_test.mojo
@@ -2,10 +2,10 @@ from std.testing import assert_equal
 from package.package import foo
 
 
-fn test_basic() raises:
+def test_basic() raises:
     assert_equal(foo(), 42)
 
 
-fn main() raises:
+def main() raises:
     print("Running tests...")
     test_basic()

--- a/tests/package/package.mojo
+++ b/tests/package/package.mojo
@@ -1,4 +1,4 @@
 import layout  # All vendored dependencies are available
 
-fn foo() -> Int:
+def foo() -> Int:
     return 42

--- a/tests/python/python_shared_library.mojo
+++ b/tests/python/python_shared_library.mojo
@@ -6,7 +6,7 @@ from std.python._cpython import PyObjectPtr
 
 
 @export
-fn PyInit_python_shared_library() -> PythonObject:
+def PyInit_python_shared_library() -> PythonObject:
     """Create a Python module with a function binding for `mojo_count_args`."""
 
     try:
@@ -22,7 +22,7 @@ fn PyInit_python_shared_library() -> PythonObject:
 
 
 @export
-fn mojo_count_args(py_self: PyObjectPtr, args: PyObjectPtr) -> PyObjectPtr:
+def mojo_count_args(py_self: PyObjectPtr, args: PyObjectPtr) -> PyObjectPtr:
     ref cpython = Python().cpython()
 
     var count = cpython.PyObject_Length(args)

--- a/tests/shared_library.mojo
+++ b/tests/shared_library.mojo
@@ -1,3 +1,3 @@
 @export
-fn foo() -> Int:
+def foo() -> Int:
     return 42


### PR DESCRIPTION
Update the toolchain to 1.0.0b2.dev2026051806 and update Mojo tests to account for the change in compiler (`fn` -> `def`).