### PR TITLE
fix: allow no mojopkg/mojoc files

### DIFF
--- a/mojo/private/toolchain.BUILD
+++ b/mojo/private/toolchain.BUILD
@@ -35,10 +35,10 @@ _INTERNAL_LIBRARIES = [
 mojo_import(
     name = "all_mojodeps",
     mojodeps = glob(
-        ["lib/mojo/**/*.mojopkg"],
-        allow_empty = False,
-    ) + glob(
-        ["lib/mojo/**/*.mojoc"],
+        [
+            "lib/mojo/**/*.mojopkg",
+            "lib/mojo/**/*.mojoc",
+        ],
         allow_empty = True,
     ),
 )


### PR DESCRIPTION
The latest nightly uses mojoc files, so this glob was failing. For now just allow both to be empty.
