### PR TITLE
Revert "ci: circumvent AVX512 issue on GHA runners (#87)"

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -6,8 +6,3 @@ info --platforms=@platforms//host
 
 common --platforms=@mojo_host_platform
 common --host_platform=@mojo_host_platform
-
-# HACK: Github Action runners using AMD EPYC CPUs have AVX512 disabled.
-# Mojo will happily generate those instructions, but then they crash at runtime.
-# Totally disable AVX512 to circumvent the issue.
-common:ci --//:mojo_copt=--target-features=-avx512f,-avx512bw,-avx512cd,-avx512dq,-avx512vl,-avx512ifma,-avx512vbmi,-avx512vbmi2,-avx512vnni,-avx512bitalg,-avx512vpopcntdq,-avx512fp16,-avx512bf16

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,4 @@ jobs:
         run: |
           bazel version
           bazel info
-      - name: CPU Info
-        run: |
-          lscpu || true
-      - run: bazel test --config=ci //...
+      - run: bazel test //...

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,3 +36,8 @@ jobs:
         run: |
           lscpu || true
       - run: bazel test //...
+      - name: Debug Session
+        if: ${{ failure() }}
+        uses: mxschmitt/action-tmate@53a5c23a925969671a6bb98ea70a4f650928ef93
+        with:
+          limit-access-to-actor: false

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,4 +32,7 @@ jobs:
         run: |
           bazel version
           bazel info
+      - name: CPU Info
+        run: |
+          lscpu || true
       - run: bazel test //...

--- a/mojo/extensions.bzl
+++ b/mojo/extensions.bzl
@@ -4,7 +4,7 @@ load("//mojo:mojo_host_platform.bzl", "mojo_host_platform")
 load("//mojo/private:mojo_gpu_toolchains_repository.bzl", "mojo_gpu_toolchains_repository")
 
 _PLATFORMS = ["linux_aarch64", "linux_x86_64", "macos_arm64"]
-_DEFAULT_VERSION = "1.0.0b2.dev2026052215"
+_DEFAULT_VERSION = "1.0.0b2.dev2026052815"
 _KNOWN_SHAS = {
     "1.0.0b2.dev2026052215": {
         "linux_aarch64": "328f9d3349ffc15ea4e0b77e29acdaf4cbb5dc86fcadb2b5e6ffef5d512697b8",

--- a/mojo/extensions.bzl
+++ b/mojo/extensions.bzl
@@ -4,8 +4,14 @@ load("//mojo:mojo_host_platform.bzl", "mojo_host_platform")
 load("//mojo/private:mojo_gpu_toolchains_repository.bzl", "mojo_gpu_toolchains_repository")
 
 _PLATFORMS = ["linux_aarch64", "linux_x86_64", "macos_arm64"]
-_DEFAULT_VERSION = "1.0.0b2.dev2026051806"
+_DEFAULT_VERSION = "1.0.0b2.dev2026052215"
 _KNOWN_SHAS = {
+    "1.0.0b2.dev2026052215": {
+        "linux_aarch64": "328f9d3349ffc15ea4e0b77e29acdaf4cbb5dc86fcadb2b5e6ffef5d512697b8",
+        "linux_x86_64": "972f51fec8402689f6ad4e131190c549d981561b779927f1f9e1fc1398d2dd6d",
+        "macos_arm64": "a577219a8bcd77fe146090947ebf4a5c716d6d530faa7612b436b80e4e3f070a",
+        "mojo_compiler_mojo_libs": "b75be5b5eff2aba892df2f555a80bd7a7b9e7210b2c52c52b1158e69a8c5a4dd",
+    },
     "1.0.0b2.dev2026051806": {
         "linux_aarch64": "224c4c1590debdff509bde74ead2da7b3eef2bc052380627e824072fe18bef05",
         "linux_x86_64": "7775e0386cb564cfd09f34c74209b80fc5a5d43b5ac20e36e638032e0f0cd63a",

--- a/tests/python/python_shared_library.mojo
+++ b/tests/python/python_shared_library.mojo
@@ -21,8 +21,7 @@ def PyInit_python_shared_library() -> PythonObject:
         abort(String("failed to create Python module: ", e))
 
 
-@export
-def mojo_count_args(py_self: PyObjectPtr, args: PyObjectPtr) -> PyObjectPtr:
+def mojo_count_args(py_self: PyObjectPtr, args: PyObjectPtr) abi("C") -> PyObjectPtr:
     ref cpython = Python().cpython()
 
     var count = cpython.PyObject_Length(args)


### PR DESCRIPTION
This reverts commit 6357c3e.