### PR TITLE
Remove support for the fire emoji as an extension

### DIFF
--- a/mojo/private/utils.bzl
+++ b/mojo/private/utils.bzl
@@ -3,7 +3,7 @@
 load("@bazel_features//:features.bzl", "bazel_features")
 load("//mojo:providers.bzl", "MojoInfo")
 
-MOJO_EXTENSIONS = ("mojo", "🔥")
+MOJO_EXTENSIONS = ("mojo",)
 
 def collect_mojoinfo(deps):
     """Get a combined MojoInfo from all the passed dependencies.


### PR DESCRIPTION
This was removed from Mojo a bit ago.
