### PR TITLE
Stage libDeviceContextGlobals alongside the mojo runtime libs

### DIFF
--- a/mojo/private/toolchain.BUILD
+++ b/mojo/private/toolchain.BUILD
@@ -13,6 +13,7 @@ _INTERNAL_LIBRARIES = [
             # Globbed to allow .so or .dylib
             "lib/libAsyncRTMojoBindings.*",
             "lib/libAsyncRTRuntimeGlobals.*",
+            "lib/libDeviceContextGlobals.*",
             "lib/libKGENCompilerRTShared.*",
             "lib/libMSupportGlobals.*",
         ],


### PR DESCRIPTION
libAsyncRTMojoBindings now carries a runtime `NEEDED` on `libDeviceContextGlobals` (the virtual-device state was split into its own shared library so a process holds exactly one copy per process). The mojo toolchain stages a fixed set of support libraries next to every compiled mojo binary, and `libDeviceContextGlobals` was missing from it, so mojo binaries fail to load with `libDeviceContextGlobals.so: cannot open shared object file` once the runtime depends on it.

Add it to the glob. `allow_empty=False` still holds over the whole list, so older mojo packages that don't ship the library keep resolving (the pattern just matches nothing).

Needed to reland modularml/modular#88716.