### PR TITLE
Add ability to import through directories

### DIFF
--- a/mojo/extensions.bzl
+++ b/mojo/extensions.bzl
@@ -4,13 +4,13 @@ load("//mojo:mojo_host_platform.bzl", "mojo_host_platform")
 load("//mojo/private:mojo_gpu_toolchains_repository.bzl", "mojo_gpu_toolchains_repository")
 
 _PLATFORMS = ["linux_aarch64", "linux_x86_64", "macos_arm64"]
-_DEFAULT_VERSION = "1.0.0b3.dev2026061206"
+_DEFAULT_VERSION = "1.0.0b3.dev2026072006"
 _KNOWN_SHAS = {
-    "1.0.0b3.dev2026061206": {
-        "linux_aarch64": "061042c815d945c8e403a13c5317d6dbd9ceef5a0ef84422ae6b6da0a2f0fe59",
-        "linux_x86_64": "b7f569472b02a35f40c8ea96ea51dac73b6c6c085e23c08ecf3613276df4f7dd",
-        "macos_arm64": "bc4106c6013994b4eb246702832c7bc6967c4f6eeaa911eccf75d2dff26d7a3a",
-        "mojo_compiler_mojo_libs": "1c99770a8a14804f810e6a2a12f1fd5b8d5c783301b38b74c785bc421ac334b9",
+    "1.0.0b3.dev2026072006": {
+        "linux_aarch64": "63ad1c8fe113abc6a617ecadc76d42a5cbcabe19a6ef01c90b5cbc4281b118e2",
+        "linux_x86_64": "72c810694ebcc514a363857e3d8f07828be994cf26a9317b50839a3f09c45fa3",
+        "macos_arm64": "f58003493298e4427bf217c26274649f0973b3fafe379c9d319e59231066fff2",
+        "mojo_compiler_mojo_libs": "27f7acea73231e93f4e9b4485d33059343d357c552b9828f2a4e2575018742a5",
     },
 }
 _PLATFORM_MAPPINGS = {

--- a/mojo/mojo_library.bzl
+++ b/mojo/mojo_library.bzl
@@ -68,13 +68,15 @@ def _mojo_library_implementation(ctx):
     for target in ctx.attr.data:
         transitive_runfiles.append(target[DefaultInfo].default_runfiles)
 
+    import_path = mojo_precmp_file.dirname + "/" + ctx.attr.import_path
+
     return [
         DefaultInfo(
             files = depset([mojo_precmp_file]),
             runfiles = ctx.runfiles(ctx.files.data).merge_all(transitive_runfiles),
         ),
         MojoInfo(
-            import_paths = depset([mojo_precmp_file.dirname], transitive = [import_paths]),
+            import_paths = depset([import_path], transitive = [import_paths]),
             mojodeps = depset([mojo_precmp_file], transitive = [transitive_mojodeps]),
         ),
         OutputGroupInfo(**output_group_kwargs),
@@ -110,6 +112,13 @@ precompile' since it does not accept many flags.
         ),
         "deps": attr.label_list(
             providers = [MojoInfo],
+        ),
+        "import_path": attr.string(
+            doc = """
+Path relative to this package where it should be imported from.
+Generally something like `.`, `..`, or `../..`.
+""",
+            default = ".",
         ),
         "data": attr.label_list(),
         "_mojo_precompile_copts": attr.label(

--- a/mojo/private/mojo_binary_test.bzl
+++ b/mojo/private/mojo_binary_test.bzl
@@ -93,8 +93,8 @@ def _find_main(name, srcs, main):
 def _format_include(arg):
     return ["-I", arg.dirname]
 
-def _format_path(arg):
-    return [arg.path]
+def _add_include(arg):
+    return ["-I", arg]
 
 def _mojo_binary_test_implementation(ctx, *, shared_library = False):
     cc_toolchain = find_cpp_toolchain(ctx)
@@ -120,8 +120,8 @@ def _mojo_binary_test_implementation(ctx, *, shared_library = False):
             args.add_all([file], map_each = _format_include)
 
     all_deps = ctx.attr.deps + mojo_toolchain.implicit_deps + ([ctx.attr._link_extra_lib] if ctx.attr._link_extra_lib else [])
-    _, transitive_mojodeps = collect_mojoinfo(all_deps)
-    args.add_all(transitive_mojodeps, map_each = _format_include)
+    transitive_includes, transitive_mojodeps = collect_mojoinfo(all_deps)
+    args.add_all(transitive_includes, map_each = _add_include)
 
     # NOTE: Argument order:
     # 1. Basic functional arguments

--- a/tests/nested/BUILD.bazel
+++ b/tests/nested/BUILD.bazel
@@ -1,0 +1,8 @@
+load("//mojo:mojo_test.bzl", "mojo_test")
+
+mojo_test(
+    name = "main",
+    srcs = ["main.mojo"],
+    visibility = ["//tests:__subpackages__"],
+    deps = ["//tests/nested/outer:inner"],
+)

--- a/tests/nested/main.mojo
+++ b/tests/nested/main.mojo
@@ -1,0 +1,4 @@
+from outer.inner import get_five
+
+def main():
+    print(get_five())

--- a/tests/nested/outer/BUILD.bazel
+++ b/tests/nested/outer/BUILD.bazel
@@ -1,0 +1,10 @@
+load("//mojo:mojo_library.bzl", "mojo_library")
+
+mojo_library(
+    name = "inner",
+    srcs = [
+        "__init__.mojo",
+    ],
+    import_path = "..",
+    visibility = ["//tests:__subpackages__"],
+)

--- a/tests/nested/outer/__init__.mojo
+++ b/tests/nested/outer/__init__.mojo
@@ -1,0 +1,2 @@
+def get_five() -> Int:
+    return 5

--- a/tests/python/python_shared_library.mojo
+++ b/tests/python/python_shared_library.mojo
@@ -6,7 +6,7 @@ from std.python._cpython import PyObjectPtr
 
 
 @export
-def PyInit_python_shared_library() -> PythonObject:
+def PyInit_python_shared_library() abi("C") -> PythonObject:
     """Create a Python module with a function binding for `mojo_count_args`."""
 
     try:


### PR DESCRIPTION
https://github.com/modular/modular/commit/abc342fae5bc4f66dd7fc937444139225878c224 adds this functionality, plumbing it through here. Now we can set `import_path`, similar to rules_python's `imports`, but restricting it to only one possible way to import a package. (There's no hard reason for this restriction, but for now it generally makes sense that there should only be one.)

Also bumps the default Mojo version (to pull this change) and fixes a warning.
