### PR TITLE
Allow CC dependencies to propagate through mojo_library targets

### DIFF
--- a/mojo/mojo_import.bzl
+++ b/mojo/mojo_import.bzl
@@ -5,7 +5,7 @@ load("//mojo/private:utils.bzl", "collect_mojoinfo")
 
 def _mojo_import_impl(ctx):
     mojo_deps = ctx.files.mojodeps
-    import_paths, transitive_mojodeps = collect_mojoinfo(ctx.attr.deps)
+    import_paths, transitive_mojodeps, ccdeps = collect_mojoinfo(ctx.attr.deps)
     return [
         DefaultInfo(files = depset(mojo_deps, transitive = [transitive_mojodeps])),
         MojoInfo(
@@ -14,6 +14,7 @@ def _mojo_import_impl(ctx):
                 transitive = [import_paths],
             ),
             mojodeps = depset(mojo_deps, transitive = [transitive_mojodeps]),
+            ccdeps = ccdeps,
         ),
     ]
 

--- a/mojo/mojo_library.bzl
+++ b/mojo/mojo_library.bzl
@@ -32,7 +32,13 @@ def _mojo_library_implementation(ctx):
 
     # NOTE: cc deps are not passed to 'mojo precompile', they are only
     # propagated to the compile and link actions of the depending binary.
-    import_paths, transitive_mojodeps, ccdeps = collect_mojoinfo(ctx.attr.deps + mojo_toolchain.implicit_deps)
+    import_paths, transitive_mojodeps, _ = collect_mojoinfo(ctx.attr.deps + mojo_toolchain.implicit_deps)
+
+    # Binaries that depend on this already add the implicit deps, so there's
+    # two sources. If there's a transition on any of those targets, we can
+    # potentially depend on multiple different versions of the same binary.
+    # To avoid this, don't get CcInfo from the implicit deps.
+    _, _, ccdeps = collect_mojoinfo(ctx.attr.deps)
     root_directory = ctx.files.srcs[0].dirname
 
     file_args = ctx.actions.args()

--- a/mojo/mojo_library.bzl
+++ b/mojo/mojo_library.bzl
@@ -2,6 +2,7 @@
 other Mojo targets."""
 
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
+load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load("//mojo:providers.bzl", "MojoInfo")
 load("//mojo/private:utils.bzl", "MOJO_EXTENSIONS", "collect_mojoinfo", "format_import", "is_exec_config")
 
@@ -29,7 +30,9 @@ def _mojo_library_implementation(ctx):
         for copt in ctx.attr.copts
     ])
 
-    import_paths, transitive_mojodeps = collect_mojoinfo(ctx.attr.deps + mojo_toolchain.implicit_deps)
+    # NOTE: cc deps are not passed to 'mojo precompile', they are only
+    # propagated to the compile and link actions of the depending binary.
+    import_paths, transitive_mojodeps, ccdeps = collect_mojoinfo(ctx.attr.deps + mojo_toolchain.implicit_deps)
     root_directory = ctx.files.srcs[0].dirname
 
     file_args = ctx.actions.args()
@@ -71,6 +74,12 @@ def _mojo_library_implementation(ctx):
     for target in ctx.attr.data:
         transitive_runfiles.append(target[DefaultInfo].default_runfiles)
 
+    # cc deps may require files at runtime, such as shared libraries, so
+    # forward their runfiles to whatever ends up depending on this target.
+    for target in ctx.attr.deps:
+        if CcInfo in target:
+            transitive_runfiles.append(target[DefaultInfo].default_runfiles)
+
     return [
         DefaultInfo(
             files = depset([mojo_precmp_file]),
@@ -83,6 +92,7 @@ def _mojo_library_implementation(ctx):
                 transitive = [import_paths],
             ),
             mojodeps = depset([mojo_precmp_file], transitive = [transitive_mojodeps]),
+            ccdeps = ccdeps,
         ),
         OutputGroupInfo(**output_group_kwargs),
     ]
@@ -116,7 +126,14 @@ precompile' since it does not accept many flags.
             allow_files = MOJO_EXTENSIONS,
         ),
         "deps": attr.label_list(
-            providers = [MojoInfo],
+            providers = [[MojoInfo], [CcInfo]],
+            doc = """\
+Mojo dependencies required to compile this target.
+
+Dependencies providing CcInfo are not used when precompiling this target, they
+are propagated to the compile and link actions of the mojo_binary, mojo_test, or
+mojo_shared_library that transitively depends on it.
+""",
         ),
         "import_path": attr.string(
             doc = """

--- a/mojo/private/mojo_binary_test.bzl
+++ b/mojo/private/mojo_binary_test.bzl
@@ -117,7 +117,7 @@ def _mojo_binary_test_implementation(ctx, *, shared_library = False):
             args.add_all([file], map_each = _format_include)
 
     all_deps = ctx.attr.deps + mojo_toolchain.implicit_deps + ([ctx.attr._link_extra_lib] if ctx.attr._link_extra_lib else [])
-    transitive_includes, transitive_mojodeps = collect_mojoinfo(all_deps)
+    transitive_includes, transitive_mojodeps, ccdeps = collect_mojoinfo(all_deps)
     args.add_all(transitive_includes, map_each = format_import)
 
     # NOTE: Argument order:
@@ -199,7 +199,7 @@ def _mojo_binary_test_implementation(ctx, *, shared_library = False):
         actions = ctx.actions,
         feature_configuration = feature_configuration,
         cc_toolchain = cc_toolchain,
-        linking_contexts = [object_linking_context] + [dep[CcInfo].linking_context for dep in all_deps if CcInfo in dep],
+        linking_contexts = [object_linking_context, ccdeps.linking_context],
         name = ctx.label.name,
         user_link_flags = ctx.attr.linkopts,
         **link_kwargs
@@ -215,9 +215,7 @@ def _mojo_binary_test_implementation(ctx, *, shared_library = False):
     for target in data:
         transitive_runfiles.append(target[DefaultInfo].default_runfiles)
 
-    # Collect transitive shared libraries that must exist at runtime
     python_imports = []
-    transitive_libraries = []
     for target in all_deps:
         transitive_runfiles.append(target[DefaultInfo].default_runfiles)
 
@@ -227,13 +225,14 @@ def _mojo_binary_test_implementation(ctx, *, shared_library = False):
                 ctx.runfiles(transitive_files = target[PyInfo].transitive_sources),
             )
 
-        if CcInfo not in target:
-            continue
-        for linker_input in target[CcInfo].linking_context.linker_inputs.to_list():
-            for library in linker_input.libraries:
-                if library.dynamic_library and not library.pic_static_library and not library.static_library:
-                    transitive_libraries.append(depset([library]))
-                    transitive_runfiles.append(ctx.runfiles(transitive_files = depset([library.dynamic_library])))
+    # Collect transitive shared libraries that must exist at runtime, including
+    # those propagated through mojo_library deps
+    transitive_libraries = []
+    for linker_input in ccdeps.linking_context.linker_inputs.to_list():
+        for library in linker_input.libraries:
+            if library.dynamic_library and not library.pic_static_library and not library.static_library:
+                transitive_libraries.append(depset([library]))
+                transitive_runfiles.append(ctx.runfiles(transitive_files = depset([library.dynamic_library])))
 
     python_path = ""
     for path in depset(transitive = python_imports).to_list():

--- a/mojo/private/utils.bzl
+++ b/mojo/private/utils.bzl
@@ -2,6 +2,8 @@
 
 load("@bazel_features//:features.bzl", "bazel_features")
 load("@bazel_skylib//lib:paths.bzl", "paths")
+load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
+load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load("//mojo:providers.bzl", "MojoInfo")
 
 MOJO_EXTENSIONS = ("mojo",)
@@ -10,22 +12,33 @@ def collect_mojoinfo(deps):
     """Get a combined MojoInfo from all the passed dependencies.
 
     Args:
-        deps: A list of dependencies to collect MojoInfo from.
+        deps: A list of dependencies to collect MojoInfo and CcInfo from.
 
     Returns:
-        A tuple (imports, mojodeps) of two depsets combining every MojoInfo in
-        deps: `imports` holds struct(package, import_path) entries for building
-        -I flags, `mojodeps` holds the precompiled mojo Files for action inputs.
+        A tuple (imports, mojodeps, ccdeps): `imports` is a depset of
+        struct(package, import_path) entries for building -I flags, `mojodeps`
+        is a depset of the precompiled mojo Files for action inputs, and
+        `ccdeps` is a single merged CcInfo of every cc dependency, both those
+        depended on directly and those propagated through MojoInfo, for use in
+        final compile and link actions.
     """
     import_paths = []
     mojodeps = []
+    cc_infos = []
     for dep in deps:
         if MojoInfo in dep:
             info = dep[MojoInfo]
             mojodeps.append(info.mojodeps)
             import_paths.append(info.import_paths)
+            cc_infos.append(info.ccdeps)
+        if CcInfo in dep:
+            cc_infos.append(dep[CcInfo])
 
-    return depset(transitive = import_paths), depset(transitive = mojodeps)
+    return (
+        depset(transitive = import_paths),
+        depset(transitive = mojodeps),
+        cc_common.merge_cc_infos(cc_infos = cc_infos),
+    )
 
 def format_import(dep):
     return ["-I", paths.normalize(paths.join(dep.package.dirname, dep.import_path))]

--- a/mojo/providers.bzl
+++ b/mojo/providers.bzl
@@ -5,6 +5,7 @@ MojoInfo = provider(
     fields = {
         "import_paths": "Depset of struct(package = File, import_path = str). Each element is a mojoc file paired with its relative import path.",
         "mojodeps": "The precompiled mojo files required by the target",
+        "ccdeps": "A merged CcInfo of the cc dependencies of the target and its transitive Mojo dependencies.",
     },
 )
 

--- a/tests/cc/BUILD.bazel
+++ b/tests/cc/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 load("@rules_cc//cc:cc_import.bzl", "cc_import")
+load("//mojo:mojo_library.bzl", "mojo_library")
 load("//mojo:mojo_test.bzl", "mojo_test")
 
 mojo_test(
@@ -32,4 +33,38 @@ cc_import(
 cc_import(
     name = "bar_import",
     shared_library = ":bar",
+)
+
+# Separate set of tests for mojo_library targets propagating cc deps
+
+# Call C from Mojo
+mojo_library(
+    name = "mojo_lib",
+    srcs = [
+        "__init__.mojo",
+        "lib.mojo",
+    ],
+    deps = [
+        ":foo_import",
+    ],
+)
+
+mojo_test(
+    name = "mojo_cc_test",
+    srcs = ["mojo_cc_test.mojo"],
+    deps = [":mojo_lib"],
+)
+
+# Call C from Mojo through an intermediate mojo_library that has no cc deps of
+# its own, to verify cc deps are propagated transitively
+mojo_library(
+    name = "wrapper",
+    srcs = ["wrapper/__init__.mojo"],
+    deps = [":mojo_lib"],
+)
+
+mojo_test(
+    name = "transitive_cc_test",
+    srcs = ["transitive_cc_test.mojo"],
+    deps = [":wrapper"],
 )

--- a/tests/cc/lib.mojo
+++ b/tests/cc/lib.mojo
@@ -1,0 +1,4 @@
+from std.ffi import external_call
+
+def call_foo():
+    external_call["foo", NoneType]()

--- a/tests/cc/mojo_cc_test.mojo
+++ b/tests/cc/mojo_cc_test.mojo
@@ -1,0 +1,5 @@
+from mojo_lib.lib import call_foo
+
+
+def main() raises:
+    call_foo()

--- a/tests/cc/transitive_cc_test.mojo
+++ b/tests/cc/transitive_cc_test.mojo
@@ -1,0 +1,5 @@
+from wrapper import call_foo_indirectly
+
+
+def main() raises:
+    call_foo_indirectly()

--- a/tests/cc/wrapper/__init__.mojo
+++ b/tests/cc/wrapper/__init__.mojo
@@ -1,0 +1,5 @@
+from mojo_lib.lib import call_foo
+
+
+def call_foo_indirectly() raises:
+    call_foo()


### PR DESCRIPTION
Right now these can only be declared through mojo_binary/mojo_test targets, which are generally leaves. This allows us to use them in non-leaf targets.
