### PR TITLE
Bump to latest Mojo

### DIFF
--- a/mojo/extensions.bzl
+++ b/mojo/extensions.bzl
@@ -4,8 +4,14 @@ load("//mojo:mojo_host_platform.bzl", "mojo_host_platform")
 load("//mojo/private:mojo_gpu_toolchains_repository.bzl", "mojo_gpu_toolchains_repository")
 
 _PLATFORMS = ["linux_aarch64", "linux_x86_64", "macos_arm64"]
-_DEFAULT_VERSION = "1.0.0b3.dev2026072006"
+_DEFAULT_VERSION = "1.0.0b3.dev2026080206"
 _KNOWN_SHAS = {
+    "1.0.0b3.dev2026080206": {
+        "linux_aarch64": "42e2e9c06c91b962e1ac66155a2033a1148bcbde6417e9ea8561b59cbae8de5b",
+        "linux_x86_64": "b40788e38d4ccf1e931cd77f5bf41c7ba15b9ec3f35556b2e69a1eb09c7c359d",
+        "macos_arm64": "0b48f1f3d7face114b141792c5450ffb02bdd37955837a64e4f11b89cf4d88b5",
+        "mojo_compiler_mojo_libs": "481e6c48cfa0f4c0af53f57e450909f198ae1c54d0f3f5b7c29b0c707c6b26a9",
+    },
     "1.0.0b3.dev2026072006": {
         "linux_aarch64": "63ad1c8fe113abc6a617ecadc76d42a5cbcabe19a6ef01c90b5cbc4281b118e2",
         "linux_x86_64": "72c810694ebcc514a363857e3d8f07828be994cf26a9317b50839a3f09c45fa3",

--- a/mojo/mojo_import.bzl
+++ b/mojo/mojo_import.bzl
@@ -21,7 +21,7 @@ mojo_import = rule(
     implementation = _mojo_import_impl,
     attrs = {
         "mojodeps": attr.label_list(
-            allow_files = [".mojopkg", ".mojoc"],
+            allow_files = [".mojoc"],
             doc = "The precompiled mojo files to import.",
         ),
         "deps": attr.label_list(

--- a/mojo/private/toolchain.BUILD
+++ b/mojo/private/toolchain.BUILD
@@ -33,14 +33,8 @@ _INTERNAL_LIBRARIES = [
 ]
 
 mojo_import(
-    name = "all_mojodeps",
-    mojodeps = glob(
-        [
-            "lib/mojo/**/*.mojopkg",
-            "lib/mojo/**/*.mojoc",
-        ],
-        allow_empty = True,
-    ),
+    name = "std",
+    mojodeps = ["lib/mojo/std.mojoc"],
 )
 
 mojo_toolchain(
@@ -49,7 +43,7 @@ mojo_toolchain(
     implicit_deps = [
         name
         for name, _ in _INTERNAL_LIBRARIES
-    ] + ([":all_mojodeps"] if "{INCLUDE_MOJOPKGS}" else []),
+    ] + ([":std"] if "{INCLUDE_MOJOPKGS}" else []),
     lld = "bin/lld",
     mojo = "bin/mojo",
     visibility = ["//visibility:public"],

--- a/tests/package/package.mojo
+++ b/tests/package/package.mojo
@@ -1,4 +1,2 @@
-import layout  # All vendored dependencies are available
-
 def foo() -> Int:
     return 42


### PR DESCRIPTION
Couple changes:
- Drop references to `mojopkg`
- `layout` is now no longer included in the base package, only `std`, so simplify to just that.
